### PR TITLE
feat: Silverstripe 6 compatibility (3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
-# SilverStripe Linkable
+# SilverStripe Linkable (Dynamic Fork)
 
-This module is no longer maintained. Please checkout the following excellent alternatives
+This is the Dynamic fork of the original [sheadawson/silverstripe-linkable](https://github.com/sheadawson/silverstripe-linkable) module, which is no longer maintained upstream.
 
-* [gorriecoe/silverstripe-link](https://github.com/gorriecoe/silverstripe-link)
-* [gorriecoe/silverstripe-linkfield](https://github.com/gorriecoe/silverstripe-linkfield)
-* [silverstripe-embed](https://github.com/gorriecoe/silverstripe-embed)
+> **Note**: For new projects, consider using [silverstripe/linkfield](https://github.com/silverstripe/silverstripe-linkfield) instead. This fork is maintained for legacy compatibility.
 
 ## Requirements
 
-* SilverStripe 4.x
+* Silverstripe ^6
 * [Display Logic](https://github.com/unclecheese/silverstripe-display-logic)
 
-See 1.x branch/releases for SilverStripe 3.x support
+See `2` branch/releases for Silverstripe 5 support, `1.x` for Silverstripe 4
 
 ## Maintainers
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "replace": {
-        "sheadawson/silverstripe-linkable": "^2.0"
+        "sheadawson/silverstripe-linkable": "self.version"
     },
     "support": {
         "issues": "http://github.com/dynamic/silverstripe-linkable/issues"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "silverstripe/framework": "^5.0 || ^6.0",
         "silverstripe/vendor-plugin": "^2.0 || ^3.0",
-        "unclecheese/display-logic": "^3.0"
+        "unclecheese/display-logic": "^3.0 || ^4.0"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^3 || ^4"

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,12 @@
         "issues": "http://github.com/dynamic/silverstripe-linkable/issues"
     },
     "require": {
-        "silverstripe/framework": "^5.0",
-        "silverstripe/vendor-plugin": "^2.0",
+        "silverstripe/framework": "^5.0 || ^6.0",
+        "silverstripe/vendor-plugin": "^2.0 || ^3.0",
         "unclecheese/display-logic": "^3.0"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3"
+        "silverstripe/recipe-testing": "^3 || ^4"
     },
     "autoload": {
         "psr-4": {
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "3.x-dev"
         },
         "expose": [
             "client"

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,12 @@
         "issues": "http://github.com/dynamic/silverstripe-linkable/issues"
     },
     "require": {
-        "silverstripe/framework": "^5.0 || ^6.0",
-        "silverstripe/vendor-plugin": "^2.0 || ^3.0",
+        "silverstripe/framework": "^6",
+        "silverstripe/vendor-plugin": "^3",
         "unclecheese/display-logic": "^3.0 || ^4.0"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3 || ^4"
+        "silverstripe/recipe-testing": "^4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Extensions/LinkableDataExtension.php
+++ b/src/Extensions/LinkableDataExtension.php
@@ -4,14 +4,14 @@ namespace Sheadawson\Linkable\Extensions;
 
 use Sheadawson\Linkable\Models\Link;
 use SilverStripe\Core\Config\Config;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 
 /**
  * Class LinkableDataExtension
  * @author Ryan
  * @package Sheadawson\Linkable
  */
-class LinkableDataExtension extends DataExtension
+class LinkableDataExtension extends Extension
 {
     public function onBeforeDuplicate()
     {

--- a/src/Extensions/LinkableSiteTreeExtension.php
+++ b/src/Extensions/LinkableSiteTreeExtension.php
@@ -7,7 +7,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\Forms\TextField;
 use UncleCheese\DisplayLogic\Forms\Wrapper;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 
 /**
  * An extension to add site tree option to linkable field.
@@ -17,7 +17,7 @@ use SilverStripe\ORM\DataExtension;
  * @author  <mohamed.alsharaf@chrometoaster.com>
  * @package Sheadawson\Linkable\Extensions
  */
-class LinkableSiteTreeExtension extends DataExtension
+class LinkableSiteTreeExtension extends Extension
 {
     /**
      * @var array

--- a/src/Models/EmbeddedObject.php
+++ b/src/Models/EmbeddedObject.php
@@ -101,7 +101,7 @@ class EmbeddedObject extends DataObject
     /**
      * @return string
      */
-    public function forTemplate()
+    public function forTemplate(): string
     {
         switch ($this->Type) {
             case 'video':

--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -2,6 +2,8 @@
 
 namespace Sheadawson\Linkable\Models;
 
+use SilverStripe\Core\Validation\ValidationResult;
+
 use SilverStripe\Assets\File;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\CheckboxField;
@@ -440,7 +442,7 @@ class Link extends DataObject
      *
      * @return ValidationResult
      */
-    public function validate()
+    public function validate(): ValidationResult
     {
         $valid = true;
         $message = null;

--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -313,7 +313,7 @@ class Link extends DataObject
      *
      * @return DBHTMLText|string
      */
-    public function forTemplate()
+    public function forTemplate(): string
     {
         if ($this->LinkURL) {
             $link = $this->renderWith([

--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -13,7 +13,6 @@ use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use UncleCheese\DisplayLogic\Forms\Wrapper;
 use SilverStripe\Core\Convert;
-use SilverStripe\ORM\ValidationResult;
 use SilverStripe\ORM\DataObject;
 
 /**

--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -313,7 +313,7 @@ class Link extends DataObject
      *
      * @return DBHTMLText|string
      */
-    public function forTemplate(): string
+    public function forTemplate(): DBHTMLText|string
     {
         if ($this->LinkURL) {
             $link = $this->renderWith([


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Drop Silverstripe 5 support. Major version 3.0 requiring Silverstripe 6 only.

## Changes

### SS6 API Migrations
- **LinkableDataExtension.php**: `DataExtension` → `Extension`
- **LinkableSiteTreeExtension.php**: `DataExtension` → `Extension`
- **Link.php**: `forTemplate()` return type fix (DBHTMLText|string), ValidationResult return type
- **EmbeddedObject.php**: `forTemplate()` return type

### Dependency Standardization
- **composer.json**: `framework ^6`, `vendor-plugin ^3`, `recipe-testing ^4`
- **branch-alias**: `3.x-dev`
- **README**: Updated for Dynamic fork, SS6 requirements

## Version History

| Version | Branch | Silverstripe |
|---------|--------|-------------|
| 3.x     | master | ^6          |
| 2.x     | 2      | ^5          |
| 1.x     | 1.0/1.1| ^4          |
