### PR TITLE
fix: forTemplate() return type for SS6 compatibility

### DIFF
--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -311,9 +311,9 @@ class Link extends DataObject
     /**
      * Renders an HTML anchor tag for this link
      *
-     * @return DBHTMLText|string
+     * @return string
      */
-    public function forTemplate(): DBHTMLText|string
+    public function forTemplate(): string
     {
         if ($this->LinkURL) {
             $link = $this->renderWith([
@@ -325,7 +325,7 @@ class Link extends DataObject
             // Legacy. Recommended to use templating above.
             $this->extend('updateLinkTemplate', $this, $link);
 
-            return $link;
+            return (string) $link;
         }
 
         return '';


### PR DESCRIPTION
## Bug
SS6 `ModelData::forTemplate()` requires exact `string` return type.
Union type `DBHTMLText|string` is not compatible.

## Fix
- Change return type to `string`
- Cast `renderWith()` result to string